### PR TITLE
外部サーバーからの引用可否を設定可能に

### DIFF
--- a/samplebot.py
+++ b/samplebot.py
@@ -3,5 +3,6 @@ import os
 
 if __name__ == '__main__':
     bot = commands.Bot(command_prefix='/')
+    bot.allow_external_links = True
     bot.load_extension('dispander')
     bot.run(os.getenv('DISCORD_BOT_TOKEN'))


### PR DESCRIPTION
botvar として allow_external_links = True を追加することで、
外部サーバーからの引用を可能に設定できるようにしました。

```python
bot.allow_external_links = True
bot.load_extension('dispander')
```

refs
- [属性の有無チェック (hasattr) | Python-izm](https://www.python-izm.com/advanced/hasattr/)
- [Python: 辞書の値を属性参照する (AttrDict) - け日記](https://ohke.hateblo.jp/entry/2020/01/25/230000)
- [Pythonの正規表現モジュールreの使い方（match、search、subなど） | note.nkmk.me](https://note.nkmk.me/python-re-match-search-findall-etc/)