### PR TITLE
リアクションを押して展開されたメッセージを消去する機能の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ bot.run(token)
 on_message内のどこかで実行してください。
 
 展開したメッセージを消去する機能を使用するには`on_reaction_add`イベントもしくは`on_raw_reaction_add`イベントのどちらかでdelete_dispand関数を実行してください。
+on_raw_reaction_addの場合はキーワード引数`payload`にRawReactionActionEventを、on_reaction_addの場合はキーワード引数`user`にUser、`reaction`にReactionを指定して下さい。
 
 ```python
 import discord

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ on_message内のどこかで実行してください。
 展開したメッセージを消去する機能を使用するには`on_reaction_add`イベントもしくは`on_raw_reaction_add`イベントのどちらかでdelete_dispand関数を実行してください。
 on_raw_reaction_addの場合はキーワード引数`payload`にRawReactionActionEventを、on_reaction_addの場合はキーワード引数`user`にUser、`reaction`にReactionを指定して下さい。
 
+消去の際のリアクションを変更したい場合は環境変数`DELETE_REACTION_EMOJI`に絵文字を設定してください。
+
 ```python
 import discord
 from dispander import dispand, delete_dispand

--- a/README.md
+++ b/README.md
@@ -21,11 +21,13 @@ bot.run(token)
 
 ## 関数として使用する場合
 
-on_message内のどこかで実行してください
+on_message内のどこかで実行してください。
+
+展開したメッセージを消去する機能を使用するには`on_reaction_add`イベントもしくは`on_raw_reaction_add`イベントのどちらかでdelete_dispand関数を実行してください。
 
 ```python
 import discord
-from dispander import dispand
+from dispander import dispand, delete_dispand
 
 client = discord.Client()
 
@@ -34,6 +36,12 @@ async def on_message(message):
     if message.author.bot:
         return
     await dispand(message)
+
+
+@client.event
+async def on_raw_reaction_add(payload):
+    await delete_dispand(client, payload=payload)
+
 
 client.run(token)
 ```

--- a/dispander/module.py
+++ b/dispander/module.py
@@ -1,4 +1,6 @@
+import discord
 from discord import Embed
+from discord.embeds import EmptyEmbed
 from discord.ext import commands
 import re
 
@@ -22,17 +24,34 @@ class ExpandDiscordMessageUrl(commands.Cog):
 async def dispand(message):
     messages = await extract_message(message)
     for m in messages:
+        sent_messages = []
+
         if m.content or m.attachments:
-            await message.channel.send(embed=compose_embed(m))
+            sent_message = await message.channel.send(embed=compose_embed(m))
+            sent_messages.append(sent_message)
         # Send the second and subsequent attachments with embed (named 'embed') respectively:
         for attachment in m.attachments[1:]:
             embed = Embed()
             embed.set_image(
                 url=attachment.proxy_url
             )
-            await message.channel.send(embed=embed)
+            sent_attachment_message = await message.channel.send(embed=embed)
+            sent_messages.append(sent_attachment_message)
+
         for embed in m.embeds:
-            await message.channel.send(embed=embed)
+            sent_embed_message = await message.channel.send(embed=embed)
+            sent_messages.append(sent_embed_message)
+
+        # 一番先頭のメッセージにゴミ箱のリアクションをつける
+        main_message = sent_messages.pop(0)
+        await main_message.add_reaction("\U0001f5d1")
+        main_embed = main_message.embeds[0]
+        main_embed.set_author(
+            name=getattr(main_embed.author, "name", EmptyEmbed),
+            icon_url=getattr(main_embed.author, "icon_url", EmptyEmbed),
+            url=make_jump_url(message, m, sent_messages)
+        )
+        await main_message.edit(embed=main_embed)
 
 
 async def extract_message(message):
@@ -55,6 +74,21 @@ async def fetch_message_from_id(guild, channel_id, message_id):
     return message
 
 
+def make_jump_url(base_message, dispand_message, extra_messages):
+    """
+    make jump url which include more information
+    :param base_message: メッセージリンクが貼られていたメッセージ
+    :param dispand_message: 展開中のメッセージ
+    :param extra_messages: 展開する際にでた二つ目以降のメッセージ(e.g. 画像やembed)
+    :return: 混入が完了したメッセージリンク
+    """
+    return "{0.jump_url}?aid={1.id}&extra={2}".format(
+        dispand_message,
+        base_message.author,
+        ",".join([str(i.id) for i in extra_messages])
+    )
+
+
 def compose_embed(message):
     embed = Embed(
         description=message.content,
@@ -63,6 +97,7 @@ def compose_embed(message):
     embed.set_author(
         name=message.author.display_name,
         icon_url=message.author.avatar_url,
+        url=message.jump_url
     )
     embed.set_footer(
         text=message.channel.name,

--- a/dispander/module.py
+++ b/dispander/module.py
@@ -1,4 +1,5 @@
 from typing import Optional
+import os
 
 import discord
 from discord import Embed
@@ -15,7 +16,7 @@ regex_extra_url = (
     '&aid=(?P<author_id>[0-9]{18})'
     '&extra=(?P<extra_messages>(|[0-9,]+))'
 )
-DELETE_REACTION_EMOJI = "\U0001f5d1"
+DELETE_REACTION_EMOJI = os.environ.get("DELETE_REACTION_EMOJI", "\U0001f5d1")
 
 
 class ExpandDiscordMessageUrl(commands.Cog):

--- a/dispander/module.py
+++ b/dispander/module.py
@@ -13,7 +13,7 @@ regex_discord_message_url = (
 regex_extra_url = (
     r'\?base_aid=(?P<base_author_id>[0-9]{18})'
     '&aid=(?P<author_id>[0-9]{18})'
-    '&extra=(?P<extra_messages>[0-9,]+)'
+    '&extra=(?P<extra_messages>(|[0-9,]+))'
 )
 DELETE_REACTION_EMOJI = "\U0001f5d1"
 
@@ -160,7 +160,7 @@ def from_jump_url(url):
     return {
         "base_author_id": int(data["base_author_id"]),
         "author_id": int(data["author_id"]),
-        "extra_messages": [int(_id) for _id in data["extra_messages"].split(",")]
+        "extra_messages": [int(_id) for _id in data["extra_messages"].split(",")] if data["extra_messages"] else []
     }
 
 

--- a/dispander/module.py
+++ b/dispander/module.py
@@ -35,7 +35,7 @@ async def delete_dispand_messages_by_reaction(bot: discord.Client, payload_or_re
     if isinstance(payload_or_reaction, discord.RawReactionActionEvent):
         # when on_raw_reaction_add event
         payload = payload_or_reaction
-        if str(payload.emoji) != "\U0001f5d1":
+        if str(payload.emoji) != DELETE_REACTION_EMOJI:
             return
         if payload.user_id == bot.user.id:
             return
@@ -97,7 +97,7 @@ async def dispand(message):
 
         # 一番先頭のメッセージにゴミ箱のリアクションをつける
         main_message = sent_messages.pop(0)
-        await main_message.add_reaction("\U0001f5d1")
+        await main_message.add_reaction(DELETE_REACTION_EMOJI)
         main_embed = main_message.embeds[0]
         main_embed.set_author(
             name=getattr(main_embed.author, "name", EmptyEmbed),

--- a/dispander/module.py
+++ b/dispander/module.py
@@ -8,6 +8,11 @@ regex_discord_message_url = (
     '(?!<)https://(ptb.|canary.)?discord(app)?.com/channels/'
     '(?P<guild>[0-9]{18})/(?P<channel>[0-9]{18})/(?P<message>[0-9]{18})(?!>)'
 )
+regex_extra_url = (
+    r'\?base_aid=(?P<base_author_id>[0-9]{18})'
+    '&aid=(?P<author_id>[0-9]{18})'
+    '&extra=(?P<extra_messages>[0-9,]+)'
+)
 
 
 class ExpandDiscordMessageUrl(commands.Cog):
@@ -19,6 +24,32 @@ class ExpandDiscordMessageUrl(commands.Cog):
         if message.author.bot:
             return
         await dispand(message)
+
+    @commands.Cog.listener()
+    async def on_raw_reaction_add(self, payload: discord.RawReactionActionEvent):
+        if str(payload.emoji) != "\U0001f5d1":
+            return
+        if payload.user_id == self.bot.user.id:
+            return
+
+        channel = self.bot.get_channel(payload.channel_id)
+        message = await channel.fetch_message(payload.message_id)
+        if message.author.id != self.bot.user.id:
+            return
+        elif not message.embeds:
+            return
+
+        embed = message.embeds[0]
+        if getattr(embed.author, "url", None) is None:
+            return
+        data = from_jump_url(embed.author.url)
+        if not (data["base_author_id"] == payload.user_id or data["author_id"] == payload.user_id):
+            return
+        await message.delete()
+        for message_id in data["extra_messages"]:
+            extra_message = await channel.fetch_message(message_id)
+            if extra_message is not None:
+                await extra_message.delete()
 
 
 async def dispand(message):
@@ -82,11 +113,29 @@ def make_jump_url(base_message, dispand_message, extra_messages):
     :param extra_messages: 展開する際にでた二つ目以降のメッセージ(e.g. 画像やembed)
     :return: 混入が完了したメッセージリンク
     """
-    return "{0.jump_url}?aid={1.id}&extra={2}".format(
+    # base_aid: メッセージリンクで飛べる最初のメッセージの送信者のid
+    # aid: メッセージリンクを送信したユーザーのid
+    return "{0.jump_url}?base_aid={1.id}&aid={2.id}&extra={3}".format(
         dispand_message,
+        dispand_message.author,
         base_message.author,
         ",".join([str(i.id) for i in extra_messages])
     )
+
+
+def from_jump_url(url):
+    """
+    メッセージリンクから情報を取得します。
+    :param url: メッセージリンク
+    :return: dict
+    """
+    base_url_match = re.match(regex_discord_message_url + regex_extra_url, url)
+    data = base_url_match.groupdict()
+    return {
+        "base_author_id": int(data["base_author_id"]),
+        "author_id": int(data["author_id"]),
+        "extra_messages": [int(_id) for _id in data["extra_messages"].split(",")]
+    }
 
 
 def compose_embed(message):


### PR DESCRIPTION
リンク展開時に🗑リアクションをつけ、元メッセージの送信者とリンク送信者がリアクションをすると消せるようにしました。
メッセージリンクの引数を使って、外観を変えることなくデータを埋め込みました。

close #20 