### PR TITLE
アーカイブ済みスレッドから取得できなかった不具合の修正

### DIFF
--- a/dispander/module.py
+++ b/dispander/module.py
@@ -132,6 +132,8 @@ async def extract_message(message):
 
 async def fetch_message_from_id(guild, channel_id, message_id):
     channel = guild.get_channel_or_thread(channel_id)
+    if channel is None:
+        channel = await bot.fetch_channel(channel_id)
     message = await channel.fetch_message(message_id)
     return message
 


### PR DESCRIPTION
アーカイブ済みスレッドだとget_channel_or_thread()がNoneになるので、Noneだった時にfetch_channel()で上書きして取得するようにした。