### PR TITLE
サーバーアイコンなしでエラーが出る問題の修正

### DIFF
--- a/dispander/module.py
+++ b/dispander/module.py
@@ -175,6 +175,15 @@ def compose_embed(message):
         icon_url=message.author.avatar_url,
         url=message.jump_url
     )
+    if message.guild.icon is None:
+        embed.set_footer(
+            text=message.channel.name,
+        )
+    else:
+        embed.set_footer(
+            text=message.channel.name,
+            icon_url=message.guild.icon_url,
+        )
     embed.set_footer(
         text=message.channel.name,
         icon_url=message.guild.icon_url,

--- a/dispander/module.py
+++ b/dispander/module.py
@@ -184,10 +184,6 @@ def compose_embed(message):
             text=message.channel.name,
             icon_url=message.guild.icon_url,
         )
-    embed.set_footer(
-        text=message.channel.name,
-        icon_url=message.guild.icon_url,
-    )
     if message.attachments and message.attachments[0].proxy_url:
         embed.set_image(
             url=message.attachments[0].proxy_url


### PR DESCRIPTION
サーバーアイコンがなかった場合に
```
Traceback (most recent call last):
  File "/lib/python3.9/site-packages/discord/client.py", line 348, in _run_event
    await coro(*args, **kwargs)
  File "/cogs/dispander.py", line 36, in on_message
    await self.dispand(message)
  File "cogs/dispander.py", line 43, in dispand
    await message.channel.send(embed=self.compose_embed(m))
  File "cogs/dispander.py", line 96, in compose_embed
    icon_url=message.guild.icon.url,
AttributeError: 'NoneType' object has no attribute 'url'
```
というエラーが出るのでそれの修正になります。
単なるifでやっているだけなので適宜修正いただければと思います。